### PR TITLE
Only send relay candidates to remote peer

### DIFF
--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -91,6 +91,9 @@ export default class PCTransport {
 
     const sdpParsed = parse(offer.sdp ?? '');
     sdpParsed.media.forEach((media) => {
+      const newCandidates = media.candidates?.filter(candidate => candidate.type === 'relay');
+      media.candidates = newCandidates;
+
       if (media.type === 'audio') {
         ensureAudioNack(media);
       } else if (media.type === 'video') {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -254,12 +254,21 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     this.publisher.pc.onicecandidate = (ev) => {
       if (!ev.candidate) return;
-      log.trace('adding ICE candidate for peer', ev.candidate);
+      if (ev.candidate.type !== 'relay') {
+        log.info('not sending non-relay type ICE candidate for peer publisher', ev.candidate);
+        return;
+      }
+      log.trace('adding ICE candidate for peer publisher', ev.candidate);
       this.client.sendIceCandidate(ev.candidate, SignalTarget.PUBLISHER);
     };
 
     this.subscriber.pc.onicecandidate = (ev) => {
       if (!ev.candidate) return;
+      if (ev.candidate.type !== 'relay') {
+        log.info('not sending non-relay type ICE candidate for peer subscriber', ev.candidate);
+        return;
+      }
+      log.trace('adding ICE candidate for peer subscriber', ev.candidate);
       this.client.sendIceCandidate(ev.candidate, SignalTarget.SUBSCRIBER);
     };
 


### PR DESCRIPTION
This will keep us from leaking host interface IPs in the candidate offers.