### PR TITLE
Implement RTCRtpScriptTransform

### DIFF
--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -3,10 +3,15 @@ import log from '../logger';
 
 const manager = new E2EEManager();
 
-onmessage = async (event) => {
-  const { operation, readable, writable } = event.data;
-  log.trace('message received', { event });
-
+const handleTransform = ({
+  operation,
+  readable,
+  writable,
+}: {
+  operation: string;
+  readable: any;
+  writable: any;
+}) => {
   if (operation === 'encode') {
     const transformer = new TransformStream({
       transform: manager.encodeFunction.bind(manager),
@@ -17,12 +22,35 @@ onmessage = async (event) => {
       transform: manager.decodeFunction.bind(manager),
     });
     readable.pipeThrough(transformer).pipeTo(writable);
-  } else if (operation === 'setPassword') {
+  }
+};
+onmessage = async (event) => {
+  const { operation, readable, writable } = event.data;
+  log.trace('message received', { event });
+
+  if (operation === 'setPassword') {
     const { password } = event.data;
     await manager.setPassword(password);
   } else if (operation === 'rotateKey') {
     await manager.rotateKey();
+  } else {
+    handleTransform({ operation, readable, writable });
   }
 };
 
+// Operations using RTCRtpScriptTransform.
+// @ts-expect-error
+if (self.RTCTransformEvent) {
+  // @ts-expect-error
+  self.onrtctransform = (event: any) => {
+    const { transformer } = event;
+    const {
+      readable,
+      writable,
+      options: { operation },
+    } = transformer;
+
+    handleTransform({ operation, readable, writable });
+  };
+}
 export {};


### PR DESCRIPTION
This enables support for safari browsers. Backwards compatibility is maintained by just checking whether RTCRtpScriptTransform is available and falling back to the older createEncodedStreams.

Relevant links:
* https://trac.webkit.org/changeset/270107/webkit/
* https://bugs.webkit.org/show_bug.cgi?id=219148
* https://github.com/jitsi/jitsi-meet/issues/9585