### PR TITLE
Make vite compatible with rollup workers

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,7 +42,7 @@ export default {
     typescript({ tsconfig: './tsconfig.json' }),
     commonjs(),
     json(),
-    webWorkerLoader({ extensions: ['.js', '.ts'] }),
+    webWorkerLoader({ extensions: ['.js', '.ts'], pattern: /(.+)\?worker/ }),
     babel({
       babelHelpers: 'bundled',
       plugins: ['@babel/plugin-proposal-object-rest-spread'],

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -7,7 +7,7 @@ import { getEmptyAudioStreamTrack, getEmptyVideoStreamTrack, isMobile } from '..
 import type { VideoCodec } from './options';
 import { attachToElement, detachTrack, Track } from './Track';
 // @ts-ignore
-import Worker from 'web-worker:../../worker/worker';
+import Worker from '../../worker/worker?worker';
 import { keyRotationMs } from '../defaults';
 
 export default abstract class LocalTrack extends Track {

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -4,7 +4,7 @@ import { monitorFrequency } from '../stats';
 import { Track } from './Track';
 import log from '../../logger';
 // @ts-ignore
-import Worker from 'web-worker:../../worker/worker';
+import Worker from '../../worker/worker?worker';
 import { keyRotationMs } from '../defaults';
 
 export default abstract class RemoteTrack extends Track {


### PR DESCRIPTION
The main repository included [Vite](https://vitejs.dev/guide/) to watch and build the sample which is quite fast. As the fork uses workers, we need to adapt rollup to work with the same pattern.

Disclaimer:
Firefox does not support ecmascript modules  on workers(used by Vite), so workers won't work in dev mode for Firefox, you can find out more here:
https://github.com/vitejs/vite/issues/8621
https://caniuse.com/mdn-api_worker_worker_ecmascript_modules
https://bugzilla.mozilla.org/show_bug.cgi?id=1247687

